### PR TITLE
feat: Migrate from OpenAI to Anthropic API (Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,20 +21,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Check OPENAI_API_KEY presence
+      - name: Check ANTHROPIC_API_KEY presence
         run: |
-          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
-            echo "::error::OPENAI_API_KEY is NOT set in Settings > Secrets and variables > Actions."
+          if [ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+            echo "::error::ANTHROPIC_API_KEY is NOT set in Settings > Secrets and variables > Actions."
             exit 1
           fi
-          echo "OPENAI_API_KEY is present (value masked)."
+          echo "ANTHROPIC_API_KEY is present (value masked)."
       - name: Build
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python scripts/build.py
       - name: Review
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python scripts/review.py --strict
       - name: Commit artifacts
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ cd nullvariant
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
-# OpenAI API キー設定
-export OPENAI_API_KEY=sk-...
+# Anthropic API キー設定
+export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 ### 2. 編集フロー

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ nullvariant/
 # 1. 環境構築
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
 
 # 2. AGENT.ja.md を編集
 vim content/AGENT.ja.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai>=1.0.0
+anthropic>=0.18.0
 PyYAML>=6.0
 jsonschema>=4.22.0
 tiktoken>=0.7.0

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,8 +1,8 @@
 import os, re, json, yaml
 from pathlib import Path
-from openai import OpenAI
+from anthropic import Anthropic
 
-MODEL_DEFAULT = os.getenv("OPENAI_MODEL", "gpt-4.1")
+MODEL_DEFAULT = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-5-20250929")
 ROOT = Path(__file__).resolve().parents[1]
 JA = ROOT / "content" / "AGENT.ja.md"
 EN = ROOT / "AGENT.md"                     # ← root-level output
@@ -35,12 +35,15 @@ def inject_anchors(text: str, entries):
     return out
 
 def chat(model, system, prompt, temperature=0.0):
-    client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-    rsp = client.chat.completions.create(
-        model=model, temperature=temperature,
-        messages=([{"role":"system","content":system}]+[{"role":"user","content":prompt}])
+    client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    rsp = client.messages.create(
+        model=model,
+        max_tokens=8192,
+        temperature=temperature,
+        system=system,
+        messages=[{"role":"user","content":prompt}]
     )
-    return rsp.choices[0].message.content
+    return rsp.content[0].text
 
 def main():
     ja = load(JA)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -38,7 +38,7 @@ def chat(model, system, prompt, temperature=0.0):
     client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
     rsp = client.messages.create(
         model=model,
-        max_tokens=8192,
+        max_tokens=64000,  # Anthropic Console 確認: max 64,000
         temperature=temperature,
         system=system,
         messages=[{"role":"user","content":prompt}]

--- a/scripts/review.py
+++ b/scripts/review.py
@@ -21,7 +21,7 @@ def backtranslate(en_md: str):
     system = load(BACKPROMPT)
     rsp = client.messages.create(
         model=MODEL_DEFAULT,
-        max_tokens=8192,
+        max_tokens=64000,  # Anthropic Console 確認: max 64,000
         temperature=0.0,
         system=system,
         messages=[{"role":"user","content":en_md}]
@@ -34,7 +34,7 @@ def llm_review(jp: str, en: str, spec: str):
     prompt = f"# JA\n{jp}\n\n# EN\n{en}\n\n# YAML\n{spec}"
     rsp = client.messages.create(
         model=MODEL_DEFAULT,
-        max_tokens=8192,
+        max_tokens=64000,  # Anthropic Console 確認: max 64,000
         temperature=0.0,
         system=system,
         messages=[{"role":"user","content":prompt}]


### PR DESCRIPTION
Phase 0 の最優先タスクを完了。LLM API を Claude Sonnet 4.5 に移行。

## 変更内容

### コア実装
- scripts/build.py: OpenAI → Anthropic クライアントに変更
- scripts/review.py: 同様に Anthropic API 対応
- 環境変数: OPENAI_API_KEY → ANTHROPIC_API_KEY
- デフォルトモデル: claude-sonnet-4-5-20250929

### 依存関係
- requirements.txt: openai → anthropic パッケージに変更

### CI/CD
- .github/workflows/build.yml: 環境変数を ANTHROPIC_API_KEY に更新

### ドキュメント
- README.md: API キー設定手順を更新
- CONTRIBUTING.md: 同上

## 選定理由（PROJECT_STATUS.ja.md より）
- 思想的適合性: 88.5点（Constitutional AI = 内側美学との一致）
- 恐怖注入リスク最小（支配構文が少ない）
- YAML構造化抽出の精度が最高
- 日英翻訳品質がトップクラス

## 次のステップ
- ローカルで動作確認（要 ANTHROPIC_API_KEY）
- GitHub Secrets に ANTHROPIC_API_KEY を登録
- CI/CD パイプライン初回稼働テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)